### PR TITLE
Added activate/deactivate scripts

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -5,6 +5,7 @@ set -e
 # only link libraries we actually use
 export GSL_LIBS="-L${PREFIX}/lib -lgsl"
 
+# configure
 ./configure \
 	--prefix="${PREFIX}" \
 	--disable-doxygen \
@@ -15,6 +16,36 @@ export GSL_LIBS="-L${PREFIX}/lib -lgsl"
 	--disable-python \
 	--disable-gcc-flags \
 	--enable-silent-rules
+
+# build
 make -j ${CPU_COUNT}
+
+# check
 make -j ${CPU_COUNT} check
+
+# install
 make install
+
+# -- create activate/deactivate scripts
+PKG_NAME_UPPER=$(echo ${PKG_NAME} | awk '{ print toupper($0) }')
+
+# activate.sh
+ACTIVATE_SH="${PREFIX}/etc/conda/activate.d/activate_${PKG_NAME}.sh"
+mkdir -p $(dirname ${ACTIVATE_SH})
+cat > ${ACTIVATE_SH} << EOF
+#!/bin/bash
+export CONDA_BACKUP_${PKG_NAME_UPPER}_DATADIR="\${${PKG_NAME_UPPER}_DATADIR:-empty}"
+export ${PKG_NAME_UPPER}_DATADIR="/opt/anaconda1anaconda2anaconda3/share/${PKG_NAME}"
+EOF
+# deactivate.sh
+DEACTIVATE_SH="${PREFIX}/etc/conda/deactivate.d/deactivate_${PKG_NAME}.sh"
+mkdir -p $(dirname ${DEACTIVATE_SH})
+cat > ${DEACTIVATE_SH} << EOF
+#!/bin/bash
+if [ "\${CONDA_BACKUP_${PKG_NAME_UPPER}_DATADIR}" == "empty" ]; then
+	unset ${PKG_NAME_UPPER}_DATADIR
+else
+	export ${PKG_NAME_UPPER}_DATADIR="\${CONDA_BACKUP_${PKG_NAME_UPPER}_DATADIR}"
+fi
+unset CONDA_BACKUP_${PKG_NAME_UPPER}_DATADIR
+EOF

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1
+  number: 2
   skip: true  # [win]
 
 requirements:
@@ -35,6 +35,7 @@ requirements:
 
 test:
   commands:
+    - test ${LALSIMULATION_DATADIR} == "${PREFIX}/share/lalsimulation"  # [unix]
     - lalsimulation_version --verbose
     - lalsim-bh-qnmode -l 0 -m 0 -s 0
     - lalsim-bh-ringdown -M 10 -a 0 -r 100 -e 0.001 -i 0 -l 2 -m 2


### PR DESCRIPTION
This PR adds a (de)activate scripts to (un)set the `LALSIMULATION_DATADIR` environment variable. This is basically the only useful part of `lalsimulation-user-env.sh` when working in a conda environment.

cc @skymoo

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
